### PR TITLE
fix css for long string breaking container

### DIFF
--- a/websites/code/studygolang/template/index.html
+++ b/websites/code/studygolang/template/index.html
@@ -228,6 +228,9 @@
   .home_content h2 .more {
     position:absolute;right:3px;
   }
+  .box p {
+    word-wrap: break-word;
+  }
 </style>
 {{end}}
 {{define "js"}}


### PR DESCRIPTION
左边栏的网址太长，
![screen shot 2014-09-14 at 1 54 03 am](https://cloud.githubusercontent.com/assets/87474/4261431/18ccdb40-3b6f-11e4-933c-ebf9a95fca6a.png)
