### PR TITLE
Fix(articles,wiki): 修正页面中打开后锚点不能正确定位的 BUG

### DIFF
--- a/template/articles/detail.html
+++ b/template/articles/detail.html
@@ -221,6 +221,7 @@ var objid = {{.article.Id}};
 $(function(){
 	{{if .article.Markdown}}
 	new SG.Articles().parseContent($('.page .content'));
+	location.href=location.href;
 	{{end}}
 	
 	// 文本框自动伸缩

--- a/template/wiki/content.html
+++ b/template/wiki/content.html
@@ -97,6 +97,7 @@ SG.SIDE_BARS = [
 $(function(){
   // 解析 desc
   new SG.Wiki().parseDesc();
+  location.href=location.href;
 
   // loadComments();
 });


### PR DESCRIPTION
我这里没有环境不方便测试，请 @polaris1119 测试后再予以合并。
类似问题应该在其他页面也存在，如有遗漏之处请随时指出，我再追加修改。