### PR TITLE
fix: 搜索异常时导致页面渲染异常, 搜索框 XSS 漏洞

### DIFF
--- a/http/controller/search.go
+++ b/http/controller/search.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"html"
+
 	"github.com/studygolang/studygolang/context"
 	"github.com/studygolang/studygolang/logic"
 
@@ -31,11 +33,12 @@ func (SearchController) Search(ctx echo.Context) error {
 		"q":        q,
 		"f":        field,
 	}
-	if err == nil {
-		uri := "/search?q=" + q + "&f=" + field + "&"
-		paginator := logic.NewPaginatorWithPerPage(p, rows)
-		data["pageHtml"] = paginator.SetTotal(int64(respBody.NumFound)).GetPageHtml(uri)
+	if err != nil {
+		return render(ctx, "500.html", nil)
 	}
+	uri := "/search?q=" + html.EscapeString(q) + "&f=" + field + "&"
+	paginator := logic.NewPaginatorWithPerPage(p, rows)
+	data["pageHtml"] = paginator.SetTotal(int64(respBody.NumFound)).GetPageHtml(uri)
 
 	return render(ctx, "search.html", data)
 }
@@ -60,11 +63,12 @@ func (SearchController) TagList(ctx echo.Context) error {
 		"users":    users,
 		"nodes":    nodes,
 	}
-	if err == nil {
-		uri := "/tag/" + q + "?"
-		paginator := logic.NewPaginatorWithPerPage(p, rows)
-		data["pageHtml"] = paginator.SetTotal(int64(respBody.NumFound)).GetPageHtml(uri)
+	if err != nil {
+		return render(ctx, "500.html", nil)
 	}
+	uri := "/tag/" + q + "?"
+	paginator := logic.NewPaginatorWithPerPage(p, rows)
+	data["pageHtml"] = paginator.SetTotal(int64(respBody.NumFound)).GetPageHtml(uri)
 
 	return render(ctx, "feed/tag.html", data)
 }


### PR DESCRIPTION
修复了以下两个问题：

- 当搜索请求异常时，`data["pageHtml"]` 无数据会导致 html.Render 异常，从而显示空白页面。
- 搜索框此处未对 XSS 漏洞进行处理， [点击查看 XSS 漏洞](https://studygolang.com/search?q=%22%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E)。