### PR TITLE
升级 marked 版本

### DIFF
--- a/template/common/layout.html
+++ b/template/common/layout.html
@@ -221,7 +221,7 @@
 	<script src="https://lib.baomitu.com/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
 	<script src="https://lib.baomitu.com/jquery-timeago/1.6.1/jquery.timeago.min.js"></script>
 	<script src="https://lib.baomitu.com/zoom.js/0.0.1/zoom.min.js"></script>
-	<script src="https://lib.baomitu.com/marked/0.3.6/marked.min.js"></script>
+	<script src="https://lib.baomitu.com/marked/3.0.0/marked.min.js"></script>
 	<script src="https://lib.baomitu.com/Caret.js/0.3.1/jquery.caret.min.js"></script>
 	<script src="https://lib.baomitu.com/emojify.js/1.1.0/js/emojify.min.js"></script>
 


### PR DESCRIPTION
markdown 在使用复选框语法时不支持，原因是目前的版本太低，因此升级。