### PR TITLE
fix: prevent open redirect in OAuth callback handlers

### DIFF
--- a/internal/http/controller/oauth.go
+++ b/internal/http/controller/oauth.go
@@ -8,6 +8,7 @@ package controller
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/studygolang/studygolang/context"
 	. "github.com/studygolang/studygolang/internal/http"
@@ -44,6 +45,10 @@ func (OAuthController) GithubCallback(ctx echo.Context) error {
 
 		redirectURL := ctx.QueryParam("redirect_url")
 		if redirectURL == "" {
+			redirectURL = "/account/edit#connection"
+		}
+		// Prevent open redirect: only allow relative paths
+		if strings.HasPrefix(redirectURL, "//") || strings.Contains(redirectURL, "://") {
 			redirectURL = "/account/edit#connection"
 		}
 		return ctx.Redirect(http.StatusSeeOther, redirectURL)
@@ -87,6 +92,10 @@ func (OAuthController) GiteaCallback(ctx echo.Context) error {
 
 		redirectURL := ctx.QueryParam("redirect_url")
 		if redirectURL == "" {
+			redirectURL = "/account/edit#connection"
+		}
+		// Prevent open redirect: only allow relative paths
+		if strings.HasPrefix(redirectURL, "//") || strings.Contains(redirectURL, "://") {
 			redirectURL = "/account/edit#connection"
 		}
 		return ctx.Redirect(http.StatusSeeOther, redirectURL)


### PR DESCRIPTION
## Summary

Prevent open redirect in OAuth callback handlers (GitHub and Gitea) by validating the `redirect_url` parameter.

## Problem

Both `GithubCallback` and `GiteaCallback` accept a `redirect_url` query parameter and redirect to it without validation:

```go
redirectURL := ctx.QueryParam("redirect_url")
if redirectURL == "" {
    redirectURL = "/account/edit#connection"
}
return ctx.Redirect(http.StatusSeeOther, redirectURL)
```

An attacker can redirect users to external phishing sites after OAuth authentication:
```
/oauth/github/callback?code=xxx&redirect_url=https://evil.com/steal
```

This is especially dangerous in OAuth flows where the user has just authenticated and trusts the redirect.

## Fix

Validate that `redirect_url` is a relative path by rejecting URLs containing `://` or starting with `//`:

```go
if strings.HasPrefix(redirectURL, "//") || strings.Contains(redirectURL, "://") {
    redirectURL = "/account/edit#connection"
}
```

Fixed in both `GithubCallback` and `GiteaCallback` handlers.

## Impact

- **Type**: Open Redirect (CWE-601)
- **Affected endpoints**: `/oauth/github/callback`, `/oauth/gitea/callback`
- **Risk**: Post-authentication phishing, credential theft
- **OWASP**: A01:2021 — Broken Access Control